### PR TITLE
Add make depends target

### DIFF
--- a/map/Makefile
+++ b/map/Makefile
@@ -1,4 +1,5 @@
 PACKAGES=core,core_bench,batteries,containers,lwt,lwt.unix
+OPAM_PACKAGES=core core_bench batteries containers lwt
 CC=ocamlfind opt -linkpkg -thread
 
 maptest.native: maptest.ml
@@ -6,6 +7,9 @@ maptest.native: maptest.ml
 
 bufftest.native: bufftest.ml
 	$(CC) -package $(PACKAGES) $< -o $@
+
+depends:
+	opam install $(OPAM_PACKAGES)
 
 clean:
 	/bin/rm -rf *.native *.cm* *.o


### PR DESCRIPTION
This helps installing the required packages on various switches.